### PR TITLE
Bugfix: allow undefined values in header object

### DIFF
--- a/integration-tests/server.test.ts
+++ b/integration-tests/server.test.ts
@@ -1,7 +1,7 @@
 import { randomUUID } from "crypto";
 import { describe, expect, test } from "vitest";
 
-import { type EventSourceHooks, EventSourcePlus } from "../src/eventSource";
+import { type EventSourceHooks, EventSourcePlus } from "../src/event-source";
 import { wait } from "../src/internal";
 import { type SseMessage } from "../src/parse";
 
@@ -165,6 +165,7 @@ describe("retry with new headers", () => {
     test("using function syntax", async () => {
         const getHeaders = () => ({
             Authorization: randomUUID(),
+            AnotherHeader: undefined,
         });
         const eventSource = new EventSourcePlus(
             `${baseUrl}/sse-invalidate-headers`,

--- a/src/_index.ts
+++ b/src/_index.ts
@@ -1,2 +1,2 @@
-export * from "./eventSource";
+export * from "./event-source";
 export * from "./parse";

--- a/src/event-source.test.ts
+++ b/src/event-source.test.ts
@@ -1,0 +1,27 @@
+import { randomInt } from "crypto";
+import { assertType, test } from "vitest";
+
+import { EventSourcePlusOptions } from "./event-source";
+import { wait } from "./internal";
+
+test("Header TypeInference", () => {
+    type HeaderInput = EventSourcePlusOptions["headers"];
+    assertType<HeaderInput>(undefined);
+    assertType<HeaderInput>(() => {
+        if (randomInt(100) >= 50) {
+            return {
+                Authorization: "test",
+            };
+        }
+        return {};
+    });
+    assertType<HeaderInput>(async () => {
+        await wait(500);
+        if (randomInt(100) >= 50) {
+            return {
+                Authorization: "test",
+            };
+        }
+        return {};
+    });
+});

--- a/src/event-source.test.ts
+++ b/src/event-source.test.ts
@@ -4,9 +4,15 @@ import { assertType, test } from "vitest";
 import { EventSourcePlusOptions } from "./event-source";
 import { wait } from "./internal";
 
-test("Header TypeInference", () => {
+test("Header Type Inference", () => {
     type HeaderInput = EventSourcePlusOptions["headers"];
     assertType<HeaderInput>(undefined);
+    assertType<HeaderInput>({
+        Authorization: "test",
+    });
+    assertType<HeaderInput>({
+        Authorization: undefined,
+    });
     assertType<HeaderInput>(() => {
         if (randomInt(100) >= 50) {
             return {

--- a/src/event-source.ts
+++ b/src/event-source.ts
@@ -72,12 +72,15 @@ export class EventSourcePlus {
         if (typeof this.options.headers === "function") {
             const result = this.options.headers();
             if ("then" in result && typeof result.then === "function") {
-                headers = await result.then((data) => data);
+                headers = (await result.then((data) => data)) as Record<
+                    string,
+                    string
+                >;
             } else {
                 headers = result as Record<string, string>;
             }
         } else {
-            headers = this.options.headers ?? {};
+            headers = (this.options.headers as Record<string, string>) ?? {};
         }
         if (typeof headers.accept !== "string") {
             headers.accept = EventStreamContentType;
@@ -192,12 +195,12 @@ export class EventSourceController {
     }
 }
 
+type HeaderMap = Record<string, string | undefined>;
+
 export interface EventSourcePlusOptions
     extends Omit<RequestInit, "method" | "headers"> {
     method?: HttpMethod;
-    headers?:
-        | Record<string, string>
-        | (() => Record<string, string> | Promise<Record<string, string>>);
+    headers?: HeaderMap | (() => HeaderMap | Promise<HeaderMap>);
     maxRetryCount?: number;
     /**
      * Max retry wait time in MS.


### PR DESCRIPTION
Makes it to where typescript doesn't complain about potentially undefined values in header objects

```ts
// Before TS would complain because "Authorization" is `string | undefined` 
new EventSourcePlus("https://example.com", {
  headers: () => {
    const token = await getToken();
    if (token) {
      return {
         Authorization: token,
     };
   }
   return {};
  }
```