### PR TITLE
bugfix: add support for \r\n and \r line delimiters

### DIFF
--- a/src/parse.test.ts
+++ b/src/parse.test.ts
@@ -3,22 +3,22 @@ import { describe, expect, test } from "vitest";
 import { messageListFromString, type SseMessage } from "./parse";
 
 describe("messagesFromString()", () => {
-    test("complete messages", () => {
-        const input = `
-id:
-data: hello world
-
-event: error
-data: you suck
-
-id: 1
-event: data
-data: hello world
-retry: 10
-
-`;
-
-        const result = messageListFromString(input);
+    describe("complete messages", () => {
+        const lines = [
+            "id:",
+            "data: hello world",
+            "",
+            "event: error",
+            "data: you suck",
+            "",
+            "id: 1",
+            "event: data",
+            "data: hello world",
+            "retry: 10",
+            "",
+            "id: 2",
+            "event: data",
+        ];
         const expectedResult: SseMessage[] = [
             {
                 id: "",
@@ -39,20 +39,40 @@ retry: 10
                 retry: 10,
             },
         ];
-        expect(result.messages).toStrictEqual(expectedResult);
+        test("LF delimiter", () => {
+            const input = lines.join("\n");
+            const result = messageListFromString(input);
+            expect(result.messages).toStrictEqual(expectedResult);
+            expect(result.leftoverData).toBe("id: 2\nevent: data");
+        });
+        test("CRLF delimiter", () => {
+            const input = lines.join("\r\n");
+            const result = messageListFromString(input);
+            expect(result.messages).toStrictEqual(expectedResult);
+            expect(result.leftoverData).toBe("id: 2\r\nevent: data");
+        });
+        test("CR delimiter", () => {
+            let input = ``;
+            for (const line of lines) {
+                if (input.length) input += "\r";
+                input += line;
+            }
+            const result = messageListFromString(input);
+            expect(result.messages).toStrictEqual(expectedResult);
+            expect(result.leftoverData).toBe("id: 2\revent: data");
+        });
     });
-
-    test("incomplete messages", () => {
-        const input = `
-id: hello
-
-data: hello world
-
-event: error
-data: hello world
-
-event: data`;
-        const result = messageListFromString(input);
+    describe("incomplete messages", () => {
+        const lines = [
+            "id: hello",
+            "",
+            "data: hello world",
+            "",
+            "event: error",
+            "data: hello world",
+            "",
+            "event: data",
+        ];
         const expectedResult: SseMessage[] = [
             {
                 id: undefined,
@@ -67,27 +87,41 @@ event: data`;
                 retry: undefined,
             },
         ];
-        expect(result.messages).toStrictEqual(expectedResult);
-        expect(result.leftoverData).toStrictEqual("event: data");
+        const expectedLeftoverData = `event: data`;
+        test("LF delimiter", () => {
+            const result = messageListFromString(lines.join("\n"));
+            expect(result.messages).toStrictEqual(expectedResult);
+            expect(result.leftoverData).toBe(expectedLeftoverData);
+        });
+        test("CRLF delimiter", () => {
+            const result = messageListFromString(lines.join("\r\n"));
+            expect(result.messages).toStrictEqual(expectedResult);
+            expect(result.leftoverData).toBe(expectedLeftoverData);
+        });
+        test("CR delimiter", () => {
+            const result = messageListFromString(lines.join("\r"));
+            expect(result.messages).toStrictEqual(expectedResult);
+            expect(result.leftoverData).toBe(expectedLeftoverData);
+        });
     });
-
-    test("skip invalid lines", () => {
-        const input = `
-:
-hello world
-hi
-hi
-        
-data: hello world
-
-:
-:
-
-data: hello world
-
-`;
-        const result = messageListFromString(input);
-        expect(result.messages).toStrictEqual([
+    describe("skip invalid lines", () => {
+        const lines = [
+            "",
+            ":",
+            "hello world",
+            "hi",
+            "hi",
+            "",
+            "data: hello world",
+            "",
+            ":",
+            ":",
+            "",
+            "data: hello world",
+            "",
+            "",
+        ];
+        const expectedOutput: SseMessage[] = [
             {
                 id: undefined,
                 event: "message",
@@ -100,6 +134,18 @@ data: hello world
                 data: "hello world",
                 retry: undefined,
             },
-        ]);
+        ];
+        test("LF delimiter", () => {
+            const result = messageListFromString(lines.join("\n"));
+            expect(result.messages).toStrictEqual(expectedOutput);
+        });
+        test("CRLF delimiter", () => {
+            const result = messageListFromString(lines.join("\r\n"));
+            expect(result.messages).toStrictEqual(expectedOutput);
+        });
+        test("CR delimiter", () => {
+            const result = messageListFromString(lines.join("\r"));
+            expect(result.messages).toStrictEqual(expectedOutput);
+        });
     });
 });


### PR DESCRIPTION
Get parser to be more spec compliant by handling `\r\n` and `\r` as line delimiters in addition to the already supported `\n` delimiter

Fixes #10 