### PR TITLE
Bugfix: handle scenario when "Content-Type" is `undefined`

### DIFF
--- a/integration-tests/server.test.ts
+++ b/integration-tests/server.test.ts
@@ -136,6 +136,34 @@ test("get request 404", async () => {
     expect(resErrorCount > 1).toBe(true);
 });
 
+test("post request 500", async () => {
+    const eventSource = new EventSourcePlus(`${baseUrl}/send-500-error`, {
+        method: "post",
+        maxRetryCount: 2,
+    });
+    let resCount = 0;
+    let resErrorCount = 0;
+    const statusCodes: number[] = [];
+    const statusMessages: string[] = [];
+    const controller = eventSource.listen({
+        onMessage() {},
+        onResponse() {
+            resCount++;
+        },
+        onResponseError(context) {
+            statusCodes.push(context.response.status);
+            statusMessages.push(context.response.statusText);
+            resErrorCount++;
+        },
+    });
+    await wait(1000);
+    controller.abort();
+    expect(resCount).toBe(2);
+    expect(resErrorCount).toBe(2);
+    expect(statusCodes).toStrictEqual([500, 500]);
+    expect(statusMessages).toStrictEqual(["Internal error", "Internal error"]);
+});
+
 test("request error(s)", async () => {
     // cspell:disable
     const eventSource = new EventSourcePlus("asldkfjasdflkjafdslkj");

--- a/integration-tests/server.ts
+++ b/integration-tests/server.ts
@@ -7,6 +7,7 @@ import {
     eventHandler,
     getHeader,
     readBody,
+    sendError,
     setResponseHeader,
     setResponseStatus,
 } from "h3";
@@ -116,6 +117,21 @@ router.delete(
         stream.onClosed(() => {
             clearInterval(interval);
         });
+    }),
+);
+
+router.post(
+    "/send-500-error",
+    eventHandler((event) => {
+        sendError(
+            event,
+            createError({
+                status: 500,
+                statusCode: 500,
+                statusMessage: "Internal error",
+                statusText: "Internal error",
+            }),
+        );
     }),
 );
 

--- a/src/event-source.test.ts
+++ b/src/event-source.test.ts
@@ -2,8 +2,11 @@ import { randomInt } from "crypto";
 import { FetchResponse } from "ofetch";
 import { assertType, test } from "vitest";
 
-import { OnResponseContext } from "../dist";
-import { _handleResponse, EventSourcePlusOptions } from "./event-source";
+import {
+    _handleResponse,
+    EventSourcePlusOptions,
+    OnResponseContext,
+} from "./event-source";
 import { wait } from "./internal";
 
 test("Header Type Inference", () => {

--- a/src/event-source.test.ts
+++ b/src/event-source.test.ts
@@ -1,7 +1,9 @@
 import { randomInt } from "crypto";
+import { FetchResponse } from "ofetch";
 import { assertType, test } from "vitest";
 
-import { EventSourcePlusOptions } from "./event-source";
+import { OnResponseContext } from "../dist";
+import { _handleResponse, EventSourcePlusOptions } from "./event-source";
 import { wait } from "./internal";
 
 test("Header Type Inference", () => {
@@ -31,3 +33,88 @@ test("Header Type Inference", () => {
         return {};
     });
 });
+
+test("onResponse passes with valid response", async () => {
+    const headers = new Headers();
+    headers.set("Content-Type", "text/event-stream");
+    const res: FetchResponse<any> = {
+        headers: headers,
+        ok: true,
+        redirected: false,
+        status: 200,
+        statusText: "Ok",
+        type: "default",
+        url: "",
+        clone: function (): Response {
+            throw new Error("Function not implemented.");
+        },
+        body: null,
+        bodyUsed: false,
+        arrayBuffer: function (): Promise<ArrayBuffer> {
+            throw new Error("Function not implemented.");
+        },
+        blob: function (): Promise<Blob> {
+            throw new Error("Function not implemented.");
+        },
+        formData: function (): Promise<FormData> {
+            throw new Error("Function not implemented.");
+        },
+        json: function (): Promise<any> {
+            throw new Error("Function not implemented.");
+        },
+        text: function (): Promise<string> {
+            throw new Error("Function not implemented.");
+        },
+    };
+    const context: OnResponseContext = {
+        request: {} as any,
+        response: res,
+        options: {},
+    };
+    await _handleResponse(context, {
+        onMessage() {},
+    });
+});
+
+test.fails(
+    "onResponse throws when Content-Type header is undefined",
+    async () => {
+        const res: FetchResponse<any> = {
+            headers: new Headers(),
+            ok: true,
+            redirected: false,
+            status: 200,
+            statusText: "Ok",
+            type: "default",
+            url: "",
+            clone: function (): Response {
+                throw new Error("Function not implemented.");
+            },
+            body: null,
+            bodyUsed: false,
+            arrayBuffer: function (): Promise<ArrayBuffer> {
+                throw new Error("Function not implemented.");
+            },
+            blob: function (): Promise<Blob> {
+                throw new Error("Function not implemented.");
+            },
+            formData: function (): Promise<FormData> {
+                throw new Error("Function not implemented.");
+            },
+            json: function (): Promise<any> {
+                throw new Error("Function not implemented.");
+            },
+            text: function (): Promise<string> {
+                throw new Error("Function not implemented.");
+            },
+        };
+        const context: OnResponseContext = {
+            request: {} as any,
+            response: res,
+            options: {},
+        };
+        await _handleResponse(context, {
+            onMessage: () => {},
+        });
+    },
+);


### PR DESCRIPTION
Fixes infinite loop that occurs if server returns `status: 200` with `Content-Type: undefined`

fixes #12 