### PR TITLE
feature: add option to customize retry strategy

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,6 +154,24 @@ const controller = eventSource.listen({
 });
 ```
 
+#### Changing the Retry Strategy (Beta)
+
+This library has two retry strategies. `always` and `on-error`.
+
+`always` is the default. It will always attempt to keep the connection open after it has been closed. This is useful for most realtime applications which need to keep a persistent connection with the backend.
+
+`on-error` will only retry if an error occurred. If an event stream was successfully received by the client it will not reconnect after the connection is closed. This is useful for short lived streams that have a fixed length (For example LLM response streams) since it means you no longer need to listen for a "DONE" event to close the connection.
+
+To change the retry strategy simply update the `retryStrategy` option:
+
+```ts
+const eventSource = new EventSourcePlus("https://example.com", {
+    retryStrategy: "on-error",
+});
+```
+
+_The `on-error` strategy is a BETA feature. If you are using this in your LLM applications or for other purposes please give feedback so that I can make sure all edge cases are being accounted for._
+
 ## Listen Hooks
 
 The `listen()` method has the following hooks:

--- a/integration-tests/server.test.ts
+++ b/integration-tests/server.test.ts
@@ -409,10 +409,10 @@ test("Custom Fetch Injection", async () => {
     expect(msgCount > 0).toBe(true);
 });
 
-test('"ON_ERROR" retry strategy does not retry after successful connection', async () => {
+test('"on-error" retry strategy does not retry after successful connection', async () => {
     const eventSource = new EventSourcePlus(
         `${baseUrl}/sse-send-10-then-close`,
-        { retryStrategy: "ON_ERROR" },
+        { retryStrategy: "on-error" },
     );
     let msgCount = 0;
     let openCount = 0;
@@ -442,11 +442,11 @@ test('"ON_ERROR" retry strategy does not retry after successful connection', asy
     expect(errCount).toBe(0);
 });
 
-test('"ON_ERROR" retry strategy does retry after error response', async () => {
+test('"on-error" retry strategy does retry after error response', async () => {
     const eventSource = new EventSourcePlus(`${baseUrl}/send-500-error`, {
         method: "post",
         maxRetryCount: 2,
-        retryStrategy: "ON_ERROR",
+        retryStrategy: "on-error",
     });
     let resCount = 0;
     let resErrorCount = 0;

--- a/integration-tests/server.test.ts
+++ b/integration-tests/server.test.ts
@@ -408,3 +408,72 @@ test("Custom Fetch Injection", async () => {
     expect(usedCustomFetch).toBe(true);
     expect(msgCount > 0).toBe(true);
 });
+
+test('"ON_ERROR" retry strategy does not retry after successful connection', async () => {
+    const eventSource = new EventSourcePlus(
+        `${baseUrl}/sse-send-10-then-close`,
+        { retryStrategy: "ON_ERROR" },
+    );
+    let msgCount = 0;
+    let openCount = 0;
+    let errCount = 0;
+    eventSource.listen({
+        onRequestError({ error }) {
+            errCount++;
+            expect(false, error.message);
+        },
+        onMessage() {
+            msgCount++;
+        },
+        onResponse() {
+            openCount++;
+        },
+        onResponseError({ error }) {
+            errCount++;
+            expect(
+                false,
+                error?.message ?? `Unexpectedly received response error`,
+            );
+        },
+    });
+    await wait(1000);
+    expect(msgCount).toBe(10);
+    expect(openCount).toBe(1);
+    expect(errCount).toBe(0);
+});
+
+test('"ON_ERROR" retry strategy does retry after error response', async () => {
+    const eventSource = new EventSourcePlus(`${baseUrl}/send-500-error`, {
+        method: "post",
+        maxRetryCount: 2,
+        retryStrategy: "ON_ERROR",
+    });
+    let resCount = 0;
+    let resErrorCount = 0;
+    const statusCodes: number[] = [];
+    const statusMessages: string[] = [];
+    await new Promise((res, rej) => {
+        const controller = eventSource.listen({
+            onMessage() {},
+            onResponse() {
+                resCount++;
+            },
+            onResponseError(context) {
+                statusCodes.push(context.response.status);
+                statusMessages.push(context.response.statusText);
+                resErrorCount++;
+                if (resCount == 2) {
+                    controller.abort();
+                    res(true);
+                }
+            },
+        });
+        setTimeout(() => {
+            rej("timeout exceeded");
+        }, 1000);
+    });
+    expect(resCount).toBe(2);
+    expect(resErrorCount).toBe(2);
+    expect(statusCodes).toStrictEqual([500, 500]);
+    expect(statusMessages).toStrictEqual(["Internal error", "Internal error"]);
+});

--- a/src/event-source.ts
+++ b/src/event-source.ts
@@ -211,6 +211,7 @@ export interface EventSourcePlusOptions
      */
     maxRetryInterval?: number;
     /**
+     * @beta
      * Set the client retry strategy.
      *
      * - `always` - The client will always attempt to reopen the connection after it has been closed. Recommended for realtime applications. (Default)

--- a/src/event-source.ts
+++ b/src/event-source.ts
@@ -145,7 +145,7 @@ export class EventSourcePlus {
         }
         if (
             controller.signal.aborted ||
-            this.options.retryStrategy === "ON_ERROR"
+            this.options.retryStrategy === "on-error"
         ) {
             return;
         }
@@ -213,12 +213,12 @@ export interface EventSourcePlusOptions
     /**
      * Set the client retry strategy.
      *
-     * - `ALWAYS` - The client will always attempt to reopen the connection after it has been closed. Recommended for realtime applications. (Default)
-     * - `ON_ERROR` - The client will only attempt to reconnect if it received an error response. Useful for short lived text streams.
+     * - `always` - The client will always attempt to reopen the connection after it has been closed. Recommended for realtime applications. (Default)
+     * - `on-error` - The client will only attempt to reconnect if it received an error response. Useful for short lived text streams.
      *
-     * @default "ALWAYS"
+     * @default "always"
      */
-    retryStrategy?: "ALWAYS" | "ON_ERROR";
+    retryStrategy?: "always" | "on-error";
 }
 
 export const HTTP_METHOD_VALS = [


### PR DESCRIPTION
This PR adds the `retryStrategy` parameter to `EventSourcePlusOptions`. `retryStrategy` can be set to either `"always"` or `"on-error"`

By default `retryStrategy` will be set to `"always"`, meaning that EventSourcePlus will attempt to always keep a connection open after it has been closed.

When set to `"on-error"`, EventSourcePlus will not auto-reconnect after successfully receiving a stream. It will only retry if has received an error response.